### PR TITLE
make services.xml compatible with latest symfony

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,28 +5,28 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="liform.add_schema_extension" class="Limenius\Liform\Form\Extension\AddLiformExtension">
+        <service id="liform.add_schema_extension" class="Limenius\Liform\Form\Extension\AddLiformExtension" public="true">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
         <!-- Normalizes FormInterface when using the symfony serializer -->
-        <service id="liform.serializer.form_error_normalizer" class="Limenius\Liform\Serializer\Normalizer\FormErrorNormalizer" public="false">
+        <service id="liform.serializer.form_error_normalizer" class="Limenius\Liform\Serializer\Normalizer\FormErrorNormalizer">
             <argument type="service" id="translator" />
             <tag name="serializer.normalizer" priority="-10" />
         </service>
 
-        <service id="liform.serializer.initial_values_normalizer" class="Limenius\Liform\Serializer\Normalizer\InitialValuesNormalizer" public="false">
+        <service id="liform.serializer.initial_values_normalizer" class="Limenius\Liform\Serializer\Normalizer\InitialValuesNormalizer">
             <tag name="serializer.normalizer" priority="-10" />
         </service>
 
-        <service id="liform.resolver" class="Limenius\Liform\Resolver"/>
+        <service id="liform.resolver" class="Limenius\Liform\Resolver" public="true"/>
 
-        <service id="Limenius\Liform\Liform" class="Limenius\Liform\Liform" public="false">
+        <service id="Limenius\Liform\Liform" class="Limenius\Liform\Liform">
             <argument type="service" id="liform.resolver" />
         </service>
-        <service id="liform" alias="Limenius\Liform\Liform"/>
+        <service id="liform" alias="Limenius\Liform\Liform" public="true"/>
 
-        <service id="liform.guesser.validator" class="Limenius\Liform\Guesser\ValidatorGuesser">
+        <service id="liform.guesser.validator" class="Limenius\Liform\Guesser\ValidatorGuesser" public="true">
             <argument type="service" id="validator.mapping.class_metadata_factory" />
         </service>
     </services>


### PR DESCRIPTION
When using a more recent version of symfony, services are private by default. I therefore removed all public=false services and changed all services without public=false to public=true.

patch was inspired from stumbling over this error message: "...service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead."

I would greatly appreciate this being published as a hotfix or minor version bump on packagist :)