### PR TITLE
Add limenius/liform 0.18 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "limenius/liform": "^0.17.0"
+    "limenius/liform": "^0.17"
   },
   "minimum-stability": "stable"
 }


### PR DESCRIPTION
Can't update limenius/liform:
```
Problem 1
    - Root composer.json requires limenius/liform ^0.18, found limenius/liform[v0.18.0] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - limenius/liform-bundle is locked to version v0.17.0 and an update of this package was not requested.
    - limenius/liform-bundle v0.17.0 requires limenius/liform ^0.17.0 -> found limenius/liform[v0.17.0] but it conflicts with your root composer.json require (^0.18).
```