### PR TITLE
Add limenius/liform 0.18 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "limenius/liform": "^0.17"
+    "limenius/liform": "^0.17|^0.18"
   },
   "minimum-stability": "stable"
 }


### PR DESCRIPTION
```
  Problem 1
    - Root composer.json requires limenius/liform-bundle ^0.18 -> satisfiable by limenius/liform-bundle[v0.18.0].
    - limenius/liform-bundle v0.18.0 requires limenius/liform ^0.17 -> found limenius/liform[v0.17.0] but it conflicts with your root composer.json require (^0.18).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```