### PR TITLE
Fix deprecation in LimeniusLiformExtension

### DIFF
--- a/DependencyInjection/LimeniusLiformExtension.php
+++ b/DependencyInjection/LimeniusLiformExtension.php
@@ -28,7 +28,7 @@ class LimeniusLiformExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('transformers.xml');


### PR DESCRIPTION
```
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Limenius\LiformBundle\DependencyInjection\LimeniusLiformExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```