### PR TITLE
Fix deprecation in ExtensionCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -25,7 +25,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
     /**
      * @inheritdoc
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('Limenius\Liform\Liform')) {
             return;


### PR DESCRIPTION
```
Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Limenius\LiformBundle\DependencyInjection\Compiler\ExtensionCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.
```